### PR TITLE
Fix color constant typo

### DIFF
--- a/app/src/main/java/com/tallaltasawar/showcase/ui/theme/Color.kt
+++ b/app/src/main/java/com/tallaltasawar/showcase/ui/theme/Color.kt
@@ -10,6 +10,6 @@ val Purple40 = Color(0xFF6650a4)
 val PurpleGrey40 = Color(0xFF625b71)
 val Red = Color(0xFFFC0052)
 
-val BlueDard100 = Color(0xFF09176B)
+val BlueDark100 = Color(0xFF09176B)
 val BlueDark80 = Color(0xFF26396B)
 val Greydark80 = Color(0xFF3B3946)

--- a/app/src/main/java/com/tallaltasawar/showcase/ui/theme/Theme.kt
+++ b/app/src/main/java/com/tallaltasawar/showcase/ui/theme/Theme.kt
@@ -13,7 +13,7 @@ import androidx.compose.ui.platform.LocalView
 import androidx.core.view.ViewCompat
 
 private val DarkColorScheme = darkColors(
-    primary = BlueDard100,
+    primary = BlueDark100,
     secondary = Red,
     primaryVariant = BlueDark80
 )


### PR DESCRIPTION
## Summary
- fix a typo in the color constant name

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68402d2f9c808320aa184d87a86e2926