### PR TITLE
Add BTC/USD graph screen

### DIFF
--- a/app/src/main/java/com/tallaltasawar/showcase/MainActivity.kt
+++ b/app/src/main/java/com/tallaltasawar/showcase/MainActivity.kt
@@ -16,6 +16,7 @@ import androidx.navigation.compose.rememberNavController
 import com.tallaltasawar.showcase.presentation.Screen
 import com.tallaltasawar.showcase.presentation.ui.CurrencyListScreen
 import com.tallaltasawar.showcase.presentation.ui.currency_detail_screen.CurrencyDetailScreen
+import com.tallaltasawar.showcase.presentation.ui.btc_usd_graph.BtcUsdGraphScreen
 import com.tallaltasawar.showcase.ui.theme.ShowcaseTheme
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -44,6 +45,11 @@ class MainActivity : ComponentActivity() {
                             route = Screen.CurrencyDetailsScreen.route + "/{currency_id}"
                         ) {
                             CurrencyDetailScreen()
+                        }
+                        composable(
+                            route = Screen.BtcUsdGraphScreen.route
+                        ) {
+                            BtcUsdGraphScreen()
                         }
                     }
                 }

--- a/app/src/main/java/com/tallaltasawar/showcase/presentation/Screen.kt
+++ b/app/src/main/java/com/tallaltasawar/showcase/presentation/Screen.kt
@@ -3,4 +3,5 @@ package com.tallaltasawar.showcase.presentation
 sealed class Screen(val route: String) {
     object CurrencyListScreen: Screen("currency_list_screen")
     object CurrencyDetailsScreen: Screen("currency_details_screen")
+    object BtcUsdGraphScreen: Screen("btc_usd_graph_screen")
 }

--- a/app/src/main/java/com/tallaltasawar/showcase/presentation/ui/CurrencyListScreen.kt
+++ b/app/src/main/java/com/tallaltasawar/showcase/presentation/ui/CurrencyListScreen.kt
@@ -1,11 +1,11 @@
 package com.tallaltasawar.showcase.presentation.ui
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -29,6 +29,18 @@ fun CurrencyListScreen(
         LazyColumn(
             modifier = Modifier.fillMaxSize()
         ) {
+            item {
+                Text(
+                    text = "View BTC/USD Graph",
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(10.dp)
+                        .clickable {
+                            navController.navigate(Screen.BtcUsdGraphScreen.route)
+                        },
+                    style = MaterialTheme.typography.h3
+                )
+            }
             items(state.currencies) { currency ->
                 CurrencyListItem(cryptoCurrency = currency, onCLick = {
                     navController.navigate(Screen.CurrencyDetailsScreen.route + "/${currency.id}")

--- a/app/src/main/java/com/tallaltasawar/showcase/presentation/ui/btc_usd_graph/BtcUsdGraphScreen.kt
+++ b/app/src/main/java/com/tallaltasawar/showcase/presentation/ui/btc_usd_graph/BtcUsdGraphScreen.kt
@@ -1,0 +1,51 @@
+package com.tallaltasawar.showcase.presentation.ui.btc_usd_graph
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun BtcUsdGraphScreen() {
+    val btcPrices = listOf(40000f, 40500f, 39800f, 41000f, 42000f, 41500f, 43000f)
+    val usdPrices = List(btcPrices.size) { 1f }
+
+    Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+        Text(
+            text = "BTC / USD Comparison",
+            style = MaterialTheme.typography.h2,
+            modifier = Modifier.padding(bottom = 16.dp)
+        )
+        LineChart(btcPrices, usdPrices, modifier = Modifier.fillMaxSize())
+    }
+}
+
+@Composable
+private fun LineChart(btc: List<Float>, usd: List<Float>, modifier: Modifier = Modifier) {
+    val maxValue = (btc + usd).maxOrNull() ?: 0f
+    Canvas(modifier = modifier) {
+        val width = size.width
+        val height = size.height
+        val stepX = width / (btc.size - 1)
+        val btcPath = Path()
+        val usdPath = Path()
+        btc.forEachIndexed { i, value ->
+            val x = stepX * i
+            val y = height - (value / maxValue) * height
+            if (i == 0) btcPath.moveTo(x, y) else btcPath.lineTo(x, y)
+        }
+        usd.forEachIndexed { i, value ->
+            val x = stepX * i
+            val y = height - (value / maxValue) * height
+            if (i == 0) usdPath.moveTo(x, y) else usdPath.lineTo(x, y)
+        }
+        drawPath(btcPath, color = Color.Green, style = Stroke(width = 5f))
+        drawPath(usdPath, color = Color.Blue, style = Stroke(width = 5f))
+    }
+}


### PR DESCRIPTION
## Summary
- add BTC/USD graph Composable
- link new graph screen in navigation
- expose graph navigation action from list screen

## Testing
- `./gradlew test --no-daemon` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68404373d1c48320bcf7b09b76ad5a69

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new BTC/USD graph screen displaying a visual comparison of Bitcoin and USD prices.
	- Added a "View BTC/USD Graph" option at the top of the currency list for easy navigation to the new graph screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->