### PR TITLE
Enhance graph screen UI

### DIFF
--- a/app/src/main/java/com/tallaltasawar/showcase/presentation/ui/CurrencyListScreen.kt
+++ b/app/src/main/java/com/tallaltasawar/showcase/presentation/ui/CurrencyListScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material.Button
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
@@ -26,26 +27,23 @@ fun CurrencyListScreen(
     Box(
         modifier = Modifier.fillMaxSize()
     ) {
-        LazyColumn(
-            modifier = Modifier.fillMaxSize()
-        ) {
-            item {
-                Text(
-                    text = "View BTC/USD Graph",
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(10.dp)
-                        .clickable {
-                            navController.navigate(Screen.BtcUsdGraphScreen.route)
-                        },
-                    style = MaterialTheme.typography.h3
-                )
+        Column(modifier = Modifier.fillMaxSize()) {
+            Button(
+                onClick = { navController.navigate(Screen.BtcUsdGraphScreen.route) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(10.dp)
+            ) {
+                Text(text = "View BTC/USD Graph")
             }
-            items(state.currencies) { currency ->
-                CurrencyListItem(cryptoCurrency = currency, onCLick = {
-                    navController.navigate(Screen.CurrencyDetailsScreen.route + "/${currency.id}")
+            LazyColumn(
+                modifier = Modifier.fillMaxSize()
+            ) {
+                items(state.currencies) { currency ->
+                    CurrencyListItem(cryptoCurrency = currency, onCLick = {
+                        navController.navigate(Screen.CurrencyDetailsScreen.route + "/${currency.id}")
+                    })
                 }
-                )
             }
         }
         if (state.error.isNotBlank()) {

--- a/app/src/main/java/com/tallaltasawar/showcase/presentation/ui/btc_usd_graph/BtcUsdGraphScreen.kt
+++ b/app/src/main/java/com/tallaltasawar/showcase/presentation/ui/btc_usd_graph/BtcUsdGraphScreen.kt
@@ -1,15 +1,19 @@
 package com.tallaltasawar.showcase.presentation.ui.btc_usd_graph
 
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.drawscope.translate
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.draw.rotate
 
 @Composable
 fun BtcUsdGraphScreen() {
@@ -22,7 +26,32 @@ fun BtcUsdGraphScreen() {
             style = MaterialTheme.typography.h2,
             modifier = Modifier.padding(bottom = 16.dp)
         )
-        LineChart(btcPrices, usdPrices, modifier = Modifier.fillMaxSize())
+        Row(modifier = Modifier.weight(1f)) {
+            Text(
+                text = "Price",
+                modifier = Modifier
+                    .padding(end = 8.dp)
+                    .rotate(-90f)
+                    .align(Alignment.CenterVertically),
+                style = MaterialTheme.typography.body2
+            )
+            LineChart(
+                btcPrices,
+                usdPrices,
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxHeight()
+            )
+        }
+        Text(
+            text = "Time",
+            modifier = Modifier
+                .padding(top = 8.dp)
+                .align(Alignment.CenterHorizontally),
+            style = MaterialTheme.typography.body2
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Legend()
     }
 }
 
@@ -45,7 +74,32 @@ private fun LineChart(btc: List<Float>, usd: List<Float>, modifier: Modifier = M
             val y = height - (value / maxValue) * height
             if (i == 0) usdPath.moveTo(x, y) else usdPath.lineTo(x, y)
         }
+        drawLine(Color.LightGray, start = androidx.compose.ui.geometry.Offset(0f, height), end = androidx.compose.ui.geometry.Offset(width, height))
+        drawLine(Color.LightGray, start = androidx.compose.ui.geometry.Offset(0f, 0f), end = androidx.compose.ui.geometry.Offset(0f, height))
+
         drawPath(btcPath, color = Color.Green, style = Stroke(width = 5f))
         drawPath(usdPath, color = Color.Blue, style = Stroke(width = 5f))
+    }
+}
+
+@Composable
+private fun Legend() {
+    Row(modifier = Modifier.padding(top = 4.dp)) {
+        LegendItem(color = Color.Green, label = "BTC")
+        Spacer(modifier = Modifier.width(16.dp))
+        LegendItem(color = Color.Blue, label = "USD")
+    }
+}
+
+@Composable
+private fun LegendItem(color: Color, label: String) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Box(
+            modifier = Modifier
+                .size(12.dp)
+                .background(color)
+        )
+        Spacer(Modifier.width(4.dp))
+        Text(text = label, style = MaterialTheme.typography.body2)
     }
 }


### PR DESCRIPTION
## Summary
- upgrade BTC/USD graph screen with axes, labels, and a legend
- update currency list screen so graph button is separate from the list

## Testing
- `./gradlew tasks --all` *(fails: Unsupported class file major version 65)*
- `./gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_6847fc62bec48320b41a06dcfc26d13a