### PR TITLE
Fix crash on null currency detail

### DIFF
--- a/app/src/main/java/com/tallaltasawar/showcase/data/dto/CurrencyDetailDto.kt
+++ b/app/src/main/java/com/tallaltasawar/showcase/data/dto/CurrencyDetailDto.kt
@@ -15,7 +15,7 @@ data class CurrencyDetailDto(
     val links: Links,
     val links_extended: List<LinksExtended>,
     val logo: String,
-    val message: String,
+    val message: String?,
     val name: String,
     val open_source: Boolean,
     val org_structure: String,

--- a/app/src/main/java/com/tallaltasawar/showcase/domain/model/CurrencyDetail.kt
+++ b/app/src/main/java/com/tallaltasawar/showcase/domain/model/CurrencyDetail.kt
@@ -9,7 +9,7 @@ data class CurrencyDetail(
     val id: String,
     val links: Links,
     val logo: String,
-    val message: String,
+    val message: String?,
     val name: String,
     val open_source: Boolean,
     val org_structure: String,


### PR DESCRIPTION
## Summary
- allow `message` field to be nullable in DTO and domain model to avoid NPE when server returns null

## Testing
- `sh gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847ffbe74148320a6730509e2f67e06

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated currency detail fields to better handle cases where message information may be missing. The message field can now be empty or absent without causing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->